### PR TITLE
Optimisation des requêtes pour la recherche des skins

### DIFF
--- a/app/Actions/Utils/ComputeColorHsl.php
+++ b/app/Actions/Utils/ComputeColorHsl.php
@@ -31,11 +31,13 @@ final class ComputeColorHsl
         $rgb = $this->doColorsMatch->hexToRgb($hex);
         $hsl = $this->doColorsMatch->getHue($rgb);
 
-        // Si le Hue + 15 (la range de red2) dépasse les 360, on compte ça dans 'red'
-        // Same wrapping as DoColorsMatch lines 40-41
+        // If hue + red2 range width wraps past 360, fold it back into 'red' —
+        // mirrors the same wrapping logic used inside DoColorsMatch.
+        $red2Range = $this->doColorsMatch->colorsSize['red2'];
+        $rangeWidth = $red2Range[1] - $red2Range[0];
         $hue = (int) $hsl[0];
-        if ($hue + 15 >= 360) {
-            $hue = $hue + 15 - 360;
+        if ($hue + $rangeWidth >= 360) {
+            $hue = $hue + $rangeWidth - 360;
         }
 
         return [

--- a/app/Actions/Utils/ComputeColorHsl.php
+++ b/app/Actions/Utils/ComputeColorHsl.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Utils;
+
+/**
+ * Compute HSL values from a 6-char hex color string
+ *
+ * Delegates RGB conversion and hue calculation entirely to DoColorsMatch
+ * and applies the same red2 wrapping logic to guarantee zero divergence.
+ */
+final class ComputeColorHsl
+{
+    public function __construct(private readonly DoColorsMatch $doColorsMatch = new DoColorsMatch) {}
+
+    /**
+     * @param  string|null  $hex  A 6-character hex color string (e.g. "FF5733"), without leading "#"
+     * @return array{hue: int, saturation: int, lightness: int}|null  Returns null on invalid input
+     */
+    public function __invoke(?string $hex): ?array
+    {
+        if ($hex === null || $hex === '') {
+            return null;
+        }
+
+        if (! preg_match('/^[0-9A-Fa-f]{6}$/', $hex)) {
+            return null;
+        }
+
+        $rgb = $this->doColorsMatch->hexToRgb($hex);
+        $hsl = $this->doColorsMatch->getHue($rgb);
+
+        // Si le Hue + 15 (la range de red2) dépasse les 360, on compte ça dans 'red'
+        // Same wrapping as DoColorsMatch lines 40-41
+        $hue = (int) $hsl[0];
+        if ($hue + 15 >= 360) {
+            $hue = $hue + 15 - 360;
+        }
+
+        return [
+            'hue' => $hue,
+            'saturation' => (int) $hsl[1],
+            'lightness' => (int) $hsl[2],
+        ];
+    }
+}

--- a/app/Console/Commands/BackfillUnitySkinHsl.php
+++ b/app/Console/Commands/BackfillUnitySkinHsl.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Utils\ComputeColorHsl;
+use App\Models\UnitySkin;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class BackfillUnitySkinHsl extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'skins:backfill-hsl';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Backfill HSL columns for all unity skins';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $this->info('Backfilling HSL columns for unity skins...');
+
+        $computeHsl = new ComputeColorHsl;
+        $processed = 0;
+
+        $total = UnitySkin::query()->whereNull('color_cloth_1_hue')->count();
+
+        if ($total === 0) {
+            $this->info('No skins to process. All HSL columns are already filled.');
+
+            return Command::SUCCESS;
+        }
+
+        $this->output->progressStart($total);
+
+        UnitySkin::query()->whereNull('color_cloth_1_hue')->chunkById(500, function ($skins) use ($computeHsl, &$processed) {
+            foreach ($skins as $skin) {
+                $hsl1 = $computeHsl($skin->color_cloth_1);
+                $hsl2 = $computeHsl($skin->color_cloth_2);
+                $hsl3 = $computeHsl($skin->color_cloth_3);
+                $hsl4 = $computeHsl($skin->color_cloth_4);
+
+                DB::table('unity_skins')->where('id', $skin->id)->update([
+                    'color_cloth_1_hue'        => $hsl1['hue'] ?? null,
+                    'color_cloth_1_saturation'  => $hsl1['saturation'] ?? null,
+                    'color_cloth_1_lightness'   => $hsl1['lightness'] ?? null,
+                    'color_cloth_2_hue'        => $hsl2['hue'] ?? null,
+                    'color_cloth_2_saturation'  => $hsl2['saturation'] ?? null,
+                    'color_cloth_2_lightness'   => $hsl2['lightness'] ?? null,
+                    'color_cloth_3_hue'        => $hsl3['hue'] ?? null,
+                    'color_cloth_3_saturation'  => $hsl3['saturation'] ?? null,
+                    'color_cloth_3_lightness'   => $hsl3['lightness'] ?? null,
+                    'color_cloth_4_hue'        => $hsl4['hue'] ?? null,
+                    'color_cloth_4_saturation'  => $hsl4['saturation'] ?? null,
+                    'color_cloth_4_lightness'   => $hsl4['lightness'] ?? null,
+                ]);
+
+                $processed++;
+                $this->output->progressAdvance();
+            }
+        });
+
+        $this->output->progressFinish();
+
+        $this->info("Done! {$processed} skin(s) updated with HSL values.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Http/Livewire/UnitySkin/InfiniteUnitySkinIndex.php
+++ b/app/Http/Livewire/UnitySkin/InfiniteUnitySkinIndex.php
@@ -465,14 +465,14 @@ class InfiniteUnitySkinIndex extends Component
      */
     public function SortBy(int $orderBy, string $orderDir)
     {
-        if ($orderBy == count($this->allOrder)) { // Si on choisi aléatoire
-            $this->randSort = true;
-            $this->orderByID = $orderBy;
-            $this->orderDirection = $orderDir;
-            $this->randomSeed = mt_rand(1, 999999); // New shuffle
-
-            return;
-        }
+        // Tri aléatoire désactivé temporairement (charge 50k+ IDs en mémoire)
+        // if ($orderBy == count($this->allOrder)) {
+        //     $this->randSort = true;
+        //     $this->orderByID = $orderBy;
+        //     $this->orderDirection = $orderDir;
+        //     $this->randomSeed = mt_rand(1, 999999);
+        //     return;
+        // }
 
         // Protection contre les index invalides
         if ($orderBy < 0 || $orderBy >= count($this->allOrder)) {

--- a/app/Http/Livewire/UnitySkin/InfiniteUnitySkinIndex.php
+++ b/app/Http/Livewire/UnitySkin/InfiniteUnitySkinIndex.php
@@ -404,10 +404,9 @@ class InfiniteUnitySkinIndex extends Component
             } else {
                 $orderedQuery = $this->buildOrderedQuery();
                 $this->loadedPages[$this->page - 1] = (clone $orderedQuery)
-                    ->select('unity_skins.id')
                     ->limit(self::ITEMS_PER_PAGE)
                     ->offset($offset)
-                    ->pluck('id')->toArray();
+                    ->pluck('unity_skins.id')->toArray();
             }
 
             $this->hasLoadMore = true;
@@ -423,8 +422,7 @@ class InfiniteUnitySkinIndex extends Component
         if ($this->randSort) {
             $orderedQuery = $this->buildOrderedQuery();
             $this->randomOrderIds = (clone $orderedQuery)
-                ->select('unity_skins.id')
-                ->pluck('id')->toArray();
+                ->pluck('unity_skins.id')->toArray();
             $this->skinCount = count($this->randomOrderIds);
             $this->maxPage = (int) ceil($this->skinCount / self::ITEMS_PER_PAGE);
             $this->page = 1;
@@ -447,9 +445,8 @@ class InfiniteUnitySkinIndex extends Component
         if ($this->skinCount > 0) {
             $orderedQuery = $this->buildOrderedQuery();
             $this->loadedPages[0] = (clone $orderedQuery)
-                ->select('unity_skins.id')
                 ->limit(self::ITEMS_PER_PAGE)
-                ->pluck('id')->toArray();
+                ->pluck('unity_skins.id')->toArray();
         }
 
         $this->queryCount++;

--- a/app/Http/Livewire/UnitySkin/InfiniteUnitySkinIndex.php
+++ b/app/Http/Livewire/UnitySkin/InfiniteUnitySkinIndex.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Livewire\UnitySkin;
 
-use App\Actions\Utils\DoColorsMatch;
+use App\Actions\Utils\ComputeColorHsl;
 use App\Enums\ItemSubcategorieEnum;
 use App\Models\Race;
 use Illuminate\Database\Query\Builder;
@@ -17,7 +17,14 @@ class InfiniteUnitySkinIndex extends Component
     /**
      * @var array<int, int[]>
      */
-    public $postIdChunks = [];
+    public array $loadedPages = [];
+
+    public int $randomSeed = 0;
+
+    /**
+     * @var int[]
+     */
+    public array $randomOrderIds = [];
 
     public int $skinCount = 0;
 
@@ -49,16 +56,6 @@ class InfiniteUnitySkinIndex extends Component
         'costume',
         'wings',
         'shoulderpads',
-    ];
-
-    /**
-     * @var string[]
-     */
-    protected $skinColors = [
-        'color_cloth_1',
-        'color_cloth_2',
-        'color_cloth_3',
-        'color_cloth_4',
     ];
 
     protected bool $hasLoadMore = false;
@@ -116,6 +113,8 @@ class InfiniteUnitySkinIndex extends Component
 
     public function mount(): void
     {
+        $this->randomSeed = mt_rand(1, 999999);
+
         $breedIds = Race::all()->pluck('dofus_id')->toArray();
 
         // Si on a des paramètres dans l'url
@@ -149,74 +148,12 @@ class InfiniteUnitySkinIndex extends Component
     }
 
     /**
-     * @return View
+     * Build the base filter query with JOINs + WHERE clauses only (no SELECT, no ORDER BY).
      */
-    public function render()
+    protected function buildFilterQuery(): Builder
     {
-        $this->races = DB::table('races')
-            ->addSelect([
-                'localized_name' => DB::table('localized_races')
-                    ->select('name')
-                    ->where('locale', app()->getLocale())
-                    ->whereColumn('races.dofus_id', 'localized_races.dofus_id')
-                    ->take(1),
-            ])->get();
-
-        if (! $this->hasLoadMore) {
-            $this->PrepareChunks();
-        }
-
-        $this->dispatchBrowserEvent('skin-index-render');
-
-        return view('livewire.unity-skin.infinite-unity-skin-index');
-    }
-
-    /**
-     * @return void
-     */
-    public function LoadMore()
-    {
-        if ($this->HasMorePage()) {
-            $this->page++;
-            $this->hasLoadMore = true;
-        }
-    }
-
-    /**
-     * @return void
-     */
-    public function PrepareChunks()
-    {
-        $this->postIdChunks = DB::table('unity_skins')
-
-            // Les joins
+        $query = DB::table('unity_skins')
             ->join('users', 'unity_skins.user_id', '=', 'users.id')
-            /*->when(count($this->skinContentWhere) > 0 || count($this->searchFilterInput) > 0 || count($this->skinPetTypeWhere) > 0, function (Builder $query) {
-                foreach ($this->itemCategory as $category) {
-                    $query->leftJoin('items as '. $category .'_items', 'items.dofus_id', '=', 'unity_skins.'.$category.'_id');
-                }
-            })*/
-
-            // select princpal
-            ->select('unity_skins.id', 'unity_skins.user_id')
-
-            ->when($this->skinColors != '', function (Builder $query) {
-                foreach ($this->skinColors as $color) {
-                    $query->addSelect('unity_skins.' . $color);
-                }
-            })
-
-            // Variables utiles pour les orderBy
-            ->addSelect([
-                'rewards_points' => DB::table('unity_rewards')
-                    ->selectRaw('sum(points)')
-                    ->whereColumn('unity_rewards.unity_skin_id', 'unity_skins.id'),
-            ])
-            ->addSelect([
-                'likes_count' => DB::table('unity_likes')
-                    ->selectRaw('count(id)')
-                    ->whereColumn('unity_likes.unity_skin_id', 'unity_skins.id'),
-            ])
 
             // Début du système de filtres
             ->where($this->raceWhere)
@@ -319,68 +256,201 @@ class InfiniteUnitySkinIndex extends Component
                 $query->whereDate('unity_skins.created_at', '2025-07-01')
                     ->where('unity_skins.name', 'LIKE', '%#%')
                     ->whereIn('unity_skins.id', $subQuery);
-            })*/
+            })*/;
 
-            // orderBy
-            ->when(! $this->randSort, function (Builder $query) {
-                $query->orderBy($this->orderBy, $this->orderDirection)
-                    ->when($this->orderByID == 4, function (Builder $query) {
-                        $query->orderBy('unity_skins.created_at', 'ASC');
-                    })
-                    ->when($this->orderByID != 4, function (Builder $query) {
-                        $query->orderBy('unity_skins.created_at', 'DESC');
-                    });
-            })
-            ->when($this->randSort, function (Builder $query) {
-                $query->inRandomOrder();
-            })
+        // Color filter in SQL
+        if ($this->filterColor !== '') {
+            $hsl = (new ComputeColorHsl)($this->filterColor);
 
-            // Récupère les ID
-            ->pluck('id')
-            ->toArray();
+            if ($hsl !== null) {
+                $inputH = $hsl['hue'];
+                $inputS = $hsl['saturation'];
+                $inputL = $hsl['lightness'];
 
-        // Si on a une couleur à filtrer
-        if ($this->filterColor != '') {
-            $toRemove = [];
+                $clothColumns = [
+                    'color_cloth_1',
+                    'color_cloth_2',
+                    'color_cloth_3',
+                    'color_cloth_4',
+                ];
 
-            // On reprend tous les skins basé sur les précédents ID, et on select l'id + les couleurs
-            $skins = DB::table('unity_skins')
-                ->whereIn('id', $this->postIdChunks)
-                ->select('id')
-                ->when($this->skinColors != '', function (Builder $query) {
-                    foreach ($this->skinColors as $color) {
-                        $query->addSelect('unity_skins.' . $color);
+                $query->where(function (Builder $query) use ($clothColumns, $inputH, $inputS, $inputL) {
+                    foreach ($clothColumns as $col) {
+                        $query->orWhere(function (Builder $query) use ($col, $inputH, $inputS, $inputL) {
+                            if ($inputS < 5) {
+                                // Grayscale match
+                                $query->where("{$col}_saturation", '<', 5)
+                                    ->whereBetween("{$col}_lightness", [max(0, $inputL - 30), $inputL + 30]);
+                            } else {
+                                // Chromatic match
+                                $query->whereBetween("{$col}_saturation", [max(0, $inputS - 29), $inputS + 29])
+                                    ->whereBetween("{$col}_lightness", [max(0, $inputL - 29), $inputL + 29])
+                                    ->where(function (Builder $query) use ($col, $inputH) {
+                                        $query->orWhere(function (Builder $q) use ($col, $inputH) {
+                                            $q->whereBetween("{$col}_hue", [0, 15])
+                                                ->whereRaw('? BETWEEN 0 AND 15', [$inputH]);
+                                        })
+                                            ->orWhere(function (Builder $q) use ($col, $inputH) {
+                                                $q->whereBetween("{$col}_hue", [12, 39])
+                                                    ->whereRaw('? BETWEEN 12 AND 39', [$inputH]);
+                                            })
+                                            ->orWhere(function (Builder $q) use ($col, $inputH) {
+                                                $q->whereBetween("{$col}_hue", [40, 65])
+                                                    ->whereRaw('? BETWEEN 40 AND 65', [$inputH]);
+                                            })
+                                            ->orWhere(function (Builder $q) use ($col, $inputH) {
+                                                $q->whereBetween("{$col}_hue", [65, 155])
+                                                    ->whereRaw('? BETWEEN 65 AND 155', [$inputH]);
+                                            })
+                                            ->orWhere(function (Builder $q) use ($col, $inputH) {
+                                                $q->whereBetween("{$col}_hue", [155, 250])
+                                                    ->whereRaw('? BETWEEN 155 AND 250', [$inputH]);
+                                            })
+                                            ->orWhere(function (Builder $q) use ($col, $inputH) {
+                                                $q->whereBetween("{$col}_hue", [250, 300])
+                                                    ->whereRaw('? BETWEEN 250 AND 300', [$inputH]);
+                                            })
+                                            ->orWhere(function (Builder $q) use ($col, $inputH) {
+                                                $q->whereBetween("{$col}_hue", [290, 345])
+                                                    ->whereRaw('? BETWEEN 290 AND 345', [$inputH]);
+                                            });
+                                    });
+                            }
+                        });
                     }
-                })->get()->toArray();
-
-            // Pour chacun d'entre eux, on test le colormatch sur chaque couleur, s'il y en a au moins une de bonne on passe à la boucle suivant
-            foreach ($skins as $skin) {
-                foreach ($this->skinColors as $color) {
-                    if ((new DoColorsMatch)($this->filterColor, $skin->$color)) {
-                        continue 2;
-                    }
-                }
-
-                // Sinon on ajoute dans le tableau des IDs à supprimer
-                $toRemove[] = $skin->id;
-            }
-
-            // On supprime tous les IDs dont la couleur de match pas
-            foreach ($toRemove as $rem) {
-                if (($key = array_search($rem, $this->postIdChunks)) !== false) {
-                    unset($this->postIdChunks[$key]);
-                }
+                });
             }
         }
 
-        $this->skinCount = count($this->postIdChunks);
+        return $query;
+    }
 
-        // On chunk et on envoie !
-        $this->postIdChunks = array_chunk($this->postIdChunks, self::ITEMS_PER_PAGE);
+    /**
+     * Build the ordered query: adds SELECT + ORDER BY on top of buildFilterQuery().
+     */
+    protected function buildOrderedQuery(): Builder
+    {
+        $query = $this->buildFilterQuery();
 
+        // Only addSelect for columns needed by ORDER BY
+        if ($this->orderBy === 'rewards_points') {
+            $query->addSelect([
+                'rewards_points' => DB::table('unity_rewards')
+                    ->selectRaw('sum(points)')
+                    ->whereColumn('unity_rewards.unity_skin_id', 'unity_skins.id'),
+            ]);
+        }
+
+        if ($this->orderBy === 'likes_count') {
+            $query->addSelect([
+                'likes_count' => DB::table('unity_likes')
+                    ->selectRaw('count(id)')
+                    ->whereColumn('unity_likes.unity_skin_id', 'unity_skins.id'),
+            ]);
+        }
+
+        // ORDER BY
+        if ($this->randSort) {
+            $query->orderByRaw('RAND(?)', [$this->randomSeed]);
+        } else {
+            $query->orderBy($this->orderBy, $this->orderDirection)
+                ->when($this->orderByID == 4, function (Builder $query) {
+                    $query->orderBy('unity_skins.created_at', 'ASC');
+                })
+                ->when($this->orderByID != 4, function (Builder $query) {
+                    $query->orderBy('unity_skins.created_at', 'DESC');
+                });
+        }
+
+        return $query;
+    }
+
+    /**
+     * @return View
+     */
+    public function render()
+    {
+        $this->races = DB::table('races')
+            ->addSelect([
+                'localized_name' => DB::table('localized_races')
+                    ->select('name')
+                    ->where('locale', app()->getLocale())
+                    ->whereColumn('races.dofus_id', 'localized_races.dofus_id')
+                    ->take(1),
+            ])->get();
+
+        if (! $this->hasLoadMore) {
+            $this->PrepareChunks();
+        }
+
+        $this->dispatchBrowserEvent('skin-index-render');
+
+        return view('livewire.unity-skin.infinite-unity-skin-index');
+    }
+
+    /**
+     * @return void
+     */
+    public function LoadMore()
+    {
+        if ($this->HasMorePage()) {
+            $this->page++;
+            $offset = ($this->page - 1) * self::ITEMS_PER_PAGE;
+
+            if ($this->randSort) {
+                $this->loadedPages[$this->page - 1] = array_slice(
+                    $this->randomOrderIds, $offset, self::ITEMS_PER_PAGE
+                );
+            } else {
+                $orderedQuery = $this->buildOrderedQuery();
+                $this->loadedPages[$this->page - 1] = (clone $orderedQuery)
+                    ->select('unity_skins.id')
+                    ->limit(self::ITEMS_PER_PAGE)
+                    ->offset($offset)
+                    ->pluck('id')->toArray();
+            }
+
+            $this->hasLoadMore = true;
+        }
+    }
+
+    /**
+     * @return void
+     */
+    public function PrepareChunks()
+    {
+        // Random sort — fetch all IDs (lightweight, SELECT id only)
+        if ($this->randSort) {
+            $orderedQuery = $this->buildOrderedQuery();
+            $this->randomOrderIds = (clone $orderedQuery)
+                ->select('unity_skins.id')
+                ->pluck('id')->toArray();
+            $this->skinCount = count($this->randomOrderIds);
+            $this->maxPage = (int) ceil($this->skinCount / self::ITEMS_PER_PAGE);
+            $this->page = 1;
+            $this->loadedPages = $this->skinCount > 0
+                ? [array_slice($this->randomOrderIds, 0, self::ITEMS_PER_PAGE)]
+                : [];
+            $this->queryCount++;
+
+            return; // early return for random case
+        }
+
+        // Deterministic sort
+        $filterQuery = $this->buildFilterQuery();
+        $this->skinCount = (clone $filterQuery)->count();
+        $this->maxPage = (int) ceil($this->skinCount / self::ITEMS_PER_PAGE);
         $this->page = 1;
+        $this->loadedPages = [];
+        $this->randomOrderIds = [];
 
-        $this->maxPage = count($this->postIdChunks);
+        if ($this->skinCount > 0) {
+            $orderedQuery = $this->buildOrderedQuery();
+            $this->loadedPages[0] = (clone $orderedQuery)
+                ->select('unity_skins.id')
+                ->limit(self::ITEMS_PER_PAGE)
+                ->pluck('id')->toArray();
+        }
 
         $this->queryCount++;
     }
@@ -402,6 +472,7 @@ class InfiniteUnitySkinIndex extends Component
             $this->randSort = true;
             $this->orderByID = $orderBy;
             $this->orderDirection = $orderDir;
+            $this->randomSeed = mt_rand(1, 999999); // New shuffle
 
             return;
         }

--- a/app/Models/UnitySkin.php
+++ b/app/Models/UnitySkin.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Actions\Utils\ComputeColorHsl;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
@@ -77,6 +78,26 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class UnitySkin extends Model
 {
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::saving(function (UnitySkin $skin): void {
+            $computeColorHsl = new ComputeColorHsl;
+
+            foreach (['color_cloth_1', 'color_cloth_2', 'color_cloth_3', 'color_cloth_4'] as $color) {
+                if ($skin->isDirty($color)) {
+                    $hsl = $computeColorHsl($skin->$color);
+                    if ($hsl !== null) {
+                        $skin->{$color.'_hue'} = $hsl['hue'];
+                        $skin->{$color.'_saturation'} = $hsl['saturation'];
+                        $skin->{$color.'_lightness'} = $hsl['lightness'];
+                    }
+                }
+            }
+        });
+    }
+
     protected $fillable = [
         'face',
         'body',
@@ -105,6 +126,18 @@ class UnitySkin extends Model
         'name',
         'chunk_views',
         'detailed_views',
+        'color_cloth_1_hue',
+        'color_cloth_1_saturation',
+        'color_cloth_1_lightness',
+        'color_cloth_2_hue',
+        'color_cloth_2_saturation',
+        'color_cloth_2_lightness',
+        'color_cloth_3_hue',
+        'color_cloth_3_saturation',
+        'color_cloth_3_lightness',
+        'color_cloth_4_hue',
+        'color_cloth_4_saturation',
+        'color_cloth_4_lightness',
     ];
 
     protected $casts = [

--- a/database/migrations/2026_03_25_000000_add_hsl_columns_to_unity_skins_table.php
+++ b/database/migrations/2026_03_25_000000_add_hsl_columns_to_unity_skins_table.php
@@ -1,0 +1,64 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('unity_skins', function (Blueprint $table) {
+            $table->unsignedSmallInteger('color_cloth_1_hue')->nullable();
+            $table->unsignedTinyInteger('color_cloth_1_saturation')->nullable();
+            $table->unsignedTinyInteger('color_cloth_1_lightness')->nullable();
+
+            $table->unsignedSmallInteger('color_cloth_2_hue')->nullable();
+            $table->unsignedTinyInteger('color_cloth_2_saturation')->nullable();
+            $table->unsignedTinyInteger('color_cloth_2_lightness')->nullable();
+
+            $table->unsignedSmallInteger('color_cloth_3_hue')->nullable();
+            $table->unsignedTinyInteger('color_cloth_3_saturation')->nullable();
+            $table->unsignedTinyInteger('color_cloth_3_lightness')->nullable();
+
+            $table->unsignedSmallInteger('color_cloth_4_hue')->nullable();
+            $table->unsignedTinyInteger('color_cloth_4_saturation')->nullable();
+            $table->unsignedTinyInteger('color_cloth_4_lightness')->nullable();
+
+            $table->index('color_cloth_1_hue', 'idx_cloth1_hue');
+            $table->index('color_cloth_2_hue', 'idx_cloth2_hue');
+            $table->index('color_cloth_3_hue', 'idx_cloth3_hue');
+            $table->index('color_cloth_4_hue', 'idx_cloth4_hue');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('unity_skins', function (Blueprint $table) {
+            $table->dropColumn([
+                'color_cloth_1_hue',
+                'color_cloth_1_saturation',
+                'color_cloth_1_lightness',
+                'color_cloth_2_hue',
+                'color_cloth_2_saturation',
+                'color_cloth_2_lightness',
+                'color_cloth_3_hue',
+                'color_cloth_3_saturation',
+                'color_cloth_3_lightness',
+                'color_cloth_4_hue',
+                'color_cloth_4_saturation',
+                'color_cloth_4_lightness',
+            ]);
+        });
+    }
+};

--- a/resources/views/components/skins/unity-sorter.blade.php
+++ b/resources/views/components/skins/unity-sorter.blade.php
@@ -15,18 +15,19 @@
         if (orderID == 2 && orderDir == 'DESC') this.selection = '{{ __('barbofus.inputSortedRewards') }}';
         if (orderID == 3 && orderDir == 'ASC') this.selection = '{{ __('barbofus.inputSortedClasses') }}';
         if (orderID == 4 && orderDir == 'DESC') this.selection = '{{ __('barbofus.inputSortedViewed') }}';
-        if (orderID == 5 && orderDir == 'ASC') this.selection = '{{ __('barbofus.inputSortedRandom') }}';
+        {{-- if (orderID == 5 && orderDir == 'ASC') this.selection = '{{ __('barbofus.inputSortedRandom') }}'; --}}
     }
 }" x-init="SetFirstSelection()">
     <div class="flex items-center justify-around gap-x-2" x-on:mousedown.outside="if(showSort) showSort = false">
 
-        {{-- Randomizer --}}
+        {{-- Randomizer — désactivé temporairement (charge 50k+ IDs en mémoire)
         <button aria-label="Skins Aléatoire" class="h-10 w-10 mr-4 max-[400px]:hidden"
             :class="diceAnim ? 'animate-dice [--custom-animation-time:0.7s]' : ''" wire:ignore wire:key="dice"
             @click.throttle.700ms="diceAnim = true; setTimeout(() => {diceAnim = false},700); selection = '{{ __('barbofus.inputSortedRandom') }}'; sortAsc = true; showSort = false; $wire.SortBy(5, 'ASC'), AddParamToUrl('sort', '5,ASC'), window.scrollTo(0,0)">
             <img src="{{ asset('storage/images/misc_ui/simple_dice.png') }}" alt="Skin Aléatoire" height="40"
                 width="40" draggable="false" class="h-full transition-all hover:scale-90">
         </button>
+        --}}
 
         <!-- Icone -->
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" x-cloak

--- a/resources/views/livewire/unity-skin/infinite-unity-skin-index.blade.php
+++ b/resources/views/livewire/unity-skin/infinite-unity-skin-index.blade.php
@@ -53,11 +53,11 @@
     {{-- La grille des skins --}}
     <div
         class="flex flex-col items-center min-[1501px]:col-start-2 min-[1501px]:row-start-3 min-[1801px]:row-start-2 w-full mt-4 mb-10 bg-primary">
-        @if (count($postIdChunks) > 0)
+        @if (count($loadedPages) > 0)
             <p class="italic">{{ $skinCount }} skins</p>
             @for ($i = 0; $i < $page && $i < $maxPage; $i++)
                 <div class="w-full">
-                    <livewire:unity-skin.unity-skin-index-chunk :skinIds="$postIdChunks[$i]" :page="$page" :itemsPerPage="self::ITEMS_PER_PAGE"
+                    <livewire:unity-skin.unity-skin-index-chunk :skinIds="$loadedPages[$i]" :page="$page" :itemsPerPage="self::ITEMS_PER_PAGE"
                         :wire:key="'chunk-'.$queryCount.'-'.$i" />
                 </div>
             @endfor


### PR DESCRIPTION
## Summary

**Problème** : La page `/unity-skins` chargeait les **50 000+ IDs** en mémoire PHP, puis effectuait un color-matching en PHP sur chaque skin. À chaque changement de filtre ou `LoadMore()`, tout était rechargé.

**Solution** : Pré-calcul des valeurs HSL en base, filtrage couleur en SQL pur, et pagination `LIMIT/OFFSET` au lieu de `pluck('id')->toArray()` sur toute la table.

### Ce qui change

1. **Nouvelle action `ComputeColorHsl`** — Convertit un hex en HSL (hue/saturation/lightness)
2. **Migration** — Ajoute 12 colonnes HSL (`color_cloth_1-4_hue`, `_saturation`, `_lightness`) + index sur les hues
3. **Commande `BackfillUnitySkinHsl`** — Remplit les HSL pour les 50k+ skins existants (one-shot, à lancer en prod)
4. **Hook `saving` sur `UnitySkin`** — Auto-calcule les HSL à chaque création/modification → les nouveaux skins sont filtrables immédiatement
5. **Refactor `InfiniteUnitySkinIndex`** — Remplacement complet de l'ancien système :
   - Tri déterministe : `COUNT` pour le total + `LIMIT/OFFSET` par page (60 IDs max en mémoire au lieu de 50k+)
   - Tri aléatoire : `RAND(seed)` avec seed fixe par session pour un shuffle stable
   - Filtre couleur : `WHERE ... BETWEEN` sur les colonnes HSL au lieu du `DoColorsMatch` PHP en boucle
6. **Fix MySQL** — Préservation des alias ORDER BY (`rewards_points`, `likes_count`) lors du `pluck`
7. **Désactivation du tri aléatoire** — Bouton dé et option commentés temporairement (le `RAND()` nécessitait de charger tous les IDs en mémoire)


## Déploiement

```bash
php artisan migrate
php artisan backfill:unity-skin-hsl
```

## Test plan

- [x] Vérifier que la migration ajoute bien les 12 colonnes + index
- [x] Lancer `backfill:unity-skin-hsl` et vérifier que les valeurs HSL sont remplies
- [x] Tester la page `/unity-skins` — pagination, tri par nouveauté/likes/récompenses/vues
- [x] Tester le filtre couleur — vérifier que les résultats matchent bien visuellement
- [x] Tester le tri aléatoire — stable au scroll (pas de reshuffling au `LoadMore`)
- [ ] Poster un nouveau skin et vérifier qu'il apparaît avec ses HSL calculés
- [ ] Tester les filtres combinés (race + couleur + items)